### PR TITLE
Removed kludgy unnecessary adding of lib paths on Windows

### DIFF
--- a/conda_requirements_dev.txt
+++ b/conda_requirements_dev.txt
@@ -9,3 +9,4 @@ ninja
 scikit-build-core
 cython-cmake
 python-build
+flake8

--- a/py_gd/__init__.py
+++ b/py_gd/__init__.py
@@ -10,18 +10,13 @@ This __init__ does some kludges to load libraries, and then does an
 from .py_gd import *
 """
 
-import sys
-import os
-
 __version__ = "2.3.3"
 
 try:
     from .py_gd import *  # noqa: F401
 except ImportError as err:
-    if str(err).startswith("DLL load failed:"):
-        raise RuntimeError("Can't find dlls for libgd, libpng, and/or libz.\n"
-                           "This kludge is only written to support Anaconda installs\n",
-                           "you may need to add some logic for other library locations",
-                           ) from err
-    else:
-        raise
+    raise RuntimeError("Can't find dlls for libgd, libpng, and/or libz.\n"
+                       "This system should work with the dependencies from conda-forge\n",
+                       "and the binary wheels provided on PyPI"
+                       "Otherwise, you may need to figure out where they are ...",
+                       ) from err

--- a/py_gd/__init__.py
+++ b/py_gd/__init__.py
@@ -15,47 +15,13 @@ import os
 
 __version__ = "2.3.3"
 
-if sys.platform.startswith('win'):
-    # This only works for Anaconda / miniconda
-    # On other  systems, logic needs to be added here.
-    libpath = os.path.join(os.path.split(sys.executable)[0], "Library", "bin")
-
-    # UGLY kludge for Windows: load the libgd dll with ctypes so it can be used by the extension
-    # import ctypes
-    # # note: need to load up the dependencies, too
-    # #       this is a serious kludge!
-    # try:
-    #     libpng = ctypes.cdll.LoadLibrary(os.path.join(libpath,'libpng16.dll'))
-    #     zlib = ctypes.cdll.LoadLibrary(os.path.join(libpath,'zlib.dll'))
-    #     libgd = ctypes.cdll.LoadLibrary(os.path.join(libpath,'libgd.dll'))
-    # except WindowsError as err:
-    #     raise WindowsError("Can't find dlls for libgd, libpng, and libz.\n"
-    #                        "This kludge is only written to support Anaconda installs")
-
-    # alternative ugly kludge: add lib dir to PATH:
-    if (os.path.isfile(os.path.join(libpath, 'libpng16.dll')) and
-            os.path.isfile(os.path.join(libpath, 'zlib.dll')) and
-            os.path.isfile(os.path.join(libpath, 'libgd.dll'))):
-        os.environ['PATH'] = libpath + os.pathsep + os.environ['PATH']
-
-        # raise RuntimeError("Can't find dlls for libgd, libpng, and libz.\n"
-        #                    "This kludge is only written to support Anaconda installs\n",
-        #                    "you may need to add some logic for other library locations",
-        #                    )
 try:
     from .py_gd import *  # noqa: F401
-
 except ImportError as err:
     if str(err).startswith("DLL load failed:"):
-        if not (os.path.isfile(os.path.join(libpath, 'libpng16.dll')) and
-                os.path.isfile(os.path.join(libpath, 'zlib.dll')) and
-                os.path.isfile(os.path.join(libpath, 'libgd.dll'))):
-            raise RuntimeError("Can't find dlls for libgd, libpng, and libz.\n"
-                               "This kludge is only written to support Anaconda installs\n",
-                               "you may need to add some logic for other library locations",
-                               )
-        else:
-            raise
+        raise RuntimeError("Can't find dlls for libgd, libpng, and/or libz.\n"
+                           "This kludge is only written to support Anaconda installs\n",
+                           "you may need to add some logic for other library locations",
+                           ) from err
     else:
         raise
-    print(err.args)


### PR DESCRIPTION
It may be that scikit-build handled this better -- or may they haven't been needed in a long time ....

In any case, it works without them on my local Windows Box and on the CI :-) 
